### PR TITLE
Add slice value encoder for dictionary

### DIFF
--- a/src/dict/Dictionary.ts
+++ b/src/dict/Dictionary.ts
@@ -156,6 +156,15 @@ export class Dictionary<K extends DictionaryKeyTypes, V> {
         },
 
         /**
+         * Create standard slice value. On serialization instead of writing cell as ref, copies it to destination
+         * @returns DictionaryValue<Slice>
+         */
+        Slice: () => {
+            return createSliceValue();
+        },
+
+
+        /**
          * Create Builder value
          * @param bytes number of bytes of a buffer
          * @returns DictionaryValue<Builder>
@@ -559,6 +568,17 @@ function createCellValue(): DictionaryValue<Cell> {
         },
         parse: (src) => {
             return src.loadRef();
+        }
+    }
+}
+
+function createSliceValue(): DictionaryValue<Slice> {
+    return {
+        serialize: (src, buidler) => {
+            buidler.storeSlice(src);
+        },
+        parse: (src) => {
+            return src;
         }
     }
 }


### PR DESCRIPTION
Needed for highload wallet for example, because in ton@12 dict.storeCell copied content of cell, instead of storing it as ref. https://github.com/TrueCarry/ton-highload-wallet/blob/master/src/contracts/highload-wallet-v2/HighloadWalletV2.ts#L110