### PR TITLE
added skip

### DIFF
--- a/src/tuple/reader.ts
+++ b/src/tuple/reader.ts
@@ -29,7 +29,7 @@ export class TupleReader {
 
     skip(number: number = 1) {
         for (let i = 0; i < number; i++) {
-            this.items.pop();
+            this.pop();
         }
         return this;
     }

--- a/src/tuple/reader.ts
+++ b/src/tuple/reader.ts
@@ -27,8 +27,8 @@ export class TupleReader {
         return res;
     }
 
-    skip(number: number = 1) {
-        for (let i = 0; i < number; i++) {
+    skip(num: number = 1) {
+        for (let i = 0; i < num; i++) {
             this.pop();
         }
         return this;

--- a/src/tuple/reader.ts
+++ b/src/tuple/reader.ts
@@ -27,6 +27,13 @@ export class TupleReader {
         return res;
     }
 
+    skip(number: number = 1) {
+        for (let i = 0; i < number; i++) {
+            this.items.pop();
+        }
+        return this;
+    }
+
     readBigNumber() {
         let popped = this.pop();
         if (popped.type !== 'int') {


### PR DESCRIPTION
Reasoning - be able to deal with get methods (example: https://github.com/ton-blockchain/token-contract/blob/main/ft/jetton-minter.fc#L109) more elegantly.

Otherwise current code looks like:
```
stack.pop()
stack.pop()
stack.pop()
stack.readCell()
```

This change will allow:
```
stack.skip(3).readCell()
```