### PR TITLE
add export to OpenedContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Added
+- export the `OpenedContract` type
+
 ## [0.45.0] - 2023-01-13
 
 ## Added

--- a/src/contract/openContract.ts
+++ b/src/contract/openContract.ts
@@ -3,7 +3,7 @@ import { Cell } from "../boc/Cell";
 import { Contract } from "./Contract";
 import { ContractProvider } from "./ContractProvider";
 
-type OpenedContract<F> = {
+export type OpenedContract<F> = {
     [P in keyof F]: P extends `${'get' | 'send'}${string}`
     ? (F[P] extends (x: ContractProvider, ...args: infer P) => infer R ? (...args: P) => R : never)
     : F[P];

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export { Contract } from './contract/Contract';
 export { ContractProvider } from './contract/ContractProvider';
 export { ContractState } from './contract/ContractState';
 export { Sender, SenderArguments } from './contract/Sender';
-export { openContract } from './contract/openContract';
+export { openContract, OpenedContract } from './contract/openContract';
 export { ComputeError } from './contract/ComputeError';
 export {
     ContractABI,


### PR DESCRIPTION
Enables explicitly specifying the type received after invoking `openContract`